### PR TITLE
Change default composite_sync value to 1

### DIFF
--- a/MiSTer.ini
+++ b/MiSTer.ini
@@ -5,7 +5,7 @@ forced_scandoubler=0   ; set to 1 to run scandoubler on VGA output always (depen
 ;ypbpr=0               ; set to 1 for YPbPr on VGA output. (obsolete. see vga_mode)
 vga_mode=rgb           ; supported modes: rgb, ypbpr, svideo, cvbs. rgb is default.
 ntsc_mode=0            ; Only for S-Video and CVBS vga_mode. 0 - normal NTSC, 1 - PAL-60, 2 - PAL-M.
-composite_sync=0       ; set to 1 for composite sync on HSync signal of VGA output.
+composite_sync=1       ; set to 1 for composite sync on HSync signal of VGA output.
 vga_scaler=0           ; set to 1 to connect VGA to scaler output.
 hdmi_audio_96k=0       ; set to 1 for 96khz/16bit HDMI audio (48khz/16bit otherwise)
 keyrah_mode=0x18d80002 ; VIDPID of keyrah for special code translation (0x23418037 for Arduino Micro)
@@ -371,3 +371,4 @@ osd_lock_time=5
 
 ; use custom main for specific core. This option should be used only inside specific core.
 ;main=some_binary_file
+


### PR DESCRIPTION
From a troubleshooting perspective, composite_sync=1 seems like a more common gotcha because more people are using consumer CRTs than monitors.

I'm wondering if it makes sense to make this change as it covers more use cases.